### PR TITLE
Brunoffsp flexiblearguments

### DIFF
--- a/examples/Echo/Program.cs
+++ b/examples/Echo/Program.cs
@@ -29,10 +29,10 @@ namespace Echo
             if (args.Length == 0) Usage();
 
             // started by chrome?
-            else if (args[args.Length - 1].StartsWith("chrome-extension://")) RunNativeMessagingHost(args);
+            else if (args.Any(arg => arg.StartsWith("chrome-extension://"))) RunNativeMessagingHost(args);
 
             // register command?
-            else if (args[args.Length - 1] == "register") RegisterNativeMessagingHost(args);
+            else if (args.Contains("register")) RegisterNativeMessagingHost(args);
 
             // invalid command line
             else InvalidCommand(args[args.Length - 1]);

--- a/examples/RelayedEcho/Program.cs
+++ b/examples/RelayedEcho/Program.cs
@@ -30,13 +30,13 @@ namespace RelayedEcho
             if (args.Length == 0) Usage();
 
             // started by chrome?
-            else if (args[args.Length - 1].StartsWith("chrome-extension://")) RunRelay(args);
+            else if (args.Any(arg => arg.StartsWith("chrome-extension://"))) RunRelay(args);
 
             // started by relay?
-            else if (args[args.Length - 1] == "process") RunProcessor(args);
+            else if (args.Contains("process")) RunProcessor(args);
 
             // register command?
-            else if (args[args.Length - 1] == "register") RegisterNativeMessagingHost(args);
+            else if (args.Contains("register")) RegisterNativeMessagingHost(args);
 
             // invalid command line
             else InvalidCommand(args[args.Length - 1]);


### PR DESCRIPTION
the args=chrome-extension detection was failing because chrome (v71) sent argument 0 = "chrome-extension://..." and argument 1 = "--parent-window=0" and the last argument was being checked against "chrome-extension://". changed it to a more flexible detection. any argument order may work now.